### PR TITLE
Fix typo in breedingDefault

### DIFF
--- a/common/src/main/resources/breedingDefault.json
+++ b/common/src/main/resources/breedingDefault.json
@@ -60,14 +60,14 @@
 		"random": "above 45"
 	  }
 	],
-	"BLUE": [
+	"GREEN": [
 	  {
 		"childColor": "WHITE",
 		"conditions": "bothParentsFedGold",
 		"random": "above 60"
 	  },
 	  {
-		"childColor": "BLUE",
+		"childColor": "GREEN",
 		"conditions": "bothParentsFedGold",
 		"random": "above 30"
 	  },
@@ -77,7 +77,7 @@
 		"random": "above 80"
 	  },
 	  {
-		"childColor": "BLUE",
+		"childColor": "GREEN",
 		"conditions": "none",
 		"random": "above 40"
 	  }


### PR DESCRIPTION
### Issue.

According to the in-game manual, breeding a Green and Blue Chocobo should result in a White Chocobo. However, White Chocobos are extremely rare than expected


### Cause

In the config file:

Green + Blue can produce either White or Blue.
However, Blue + Green is not registered as a valid combination.
Instead, Blue + Blue can produce White or Blue.

### Fix

I modified wrong Blue + Blue recipe to Blue + Green. 